### PR TITLE
Resolve "label sync fails if formernames and name both match existing labels"

### DIFF
--- a/src/helpers/get-label-diff.js
+++ b/src/helpers/get-label-diff.js
@@ -1,10 +1,15 @@
-
-const findLabel = (label, existingLabels) => existingLabels.find(
-  ({ name }) => (
-    label.name === name || 
-    Array.isArray(label.formerNames) && label.formerNames.includes(name)
-  )
+const findLabelByName = (label, existingLabels) => existingLabels.find(
+  ({ name }) => label.name === name,
 );
+
+const findLabelByFormerName = (label, existingLabels) => existingLabels.find(
+  ({ name }) =>
+    Array.isArray(label.formerNames) && label.formerNames.includes(name),
+);
+
+const findLabel = (label, existingLabels) =>
+  findLabelByName(label, existingLabels) ||
+  findLabelByFormerName(label, existingLabels);
 
 module.exports = function(existingLabels, newLabels) {
   const add = newLabels.filter(label => !findLabel(label, existingLabels));

--- a/src/helpers/get-label-diff.spec.js
+++ b/src/helpers/get-label-diff.spec.js
@@ -13,9 +13,21 @@ const existingLabels = [{
   color: 'FF0000',
   default: false,
 }, {
-  id: 753671624,
+  id: 753671625,
   url: 'https://api.github.com/repos/picter/rest-api/labels/tar',
   name: 'tar',
+  color: 'FFFF00',
+  default: false,
+}, {
+  id: 753671626,
+  url: 'https://api.github.com/repos/picter/rest-api/labels/bug',
+  name: 'bug',
+  color: 'FFFF00',
+  default: false,
+}, {
+  id: 753671627,
+  url: 'https://api.github.com/repos/picter/rest-api/labels/type+bug',
+  name: 'type: bug',
   color: 'FFFF00',
   default: false,
 }];
@@ -35,6 +47,11 @@ const targetLabels = [{
   default: false,
 }, {
   name: 'tar',
+  color: 'FF00FF',
+  default: false,
+}, {
+  name: 'type: bug',
+  formerNames: ['bug'],
   color: 'FF00FF',
   default: false,
 }];
@@ -62,6 +79,10 @@ describe('getLabelDiff', () => {
       url: 'https://api.github.com/repos/picter/rest-api/labels/tar',
       name: 'tar',
       color: 'FF00FF',
-    }])
+    }, {
+      url: 'https://api.github.com/repos/picter/rest-api/labels/type+bug',
+      name: 'type: bug',
+      color: 'FF00FF',
+    }]);
   });
 });


### PR DESCRIPTION
Closes #1.